### PR TITLE
Allow for the model to be stored in the posenet package folder

### DIFF
--- a/posenet/posenet_factory.py
+++ b/posenet/posenet_factory.py
@@ -19,6 +19,7 @@ def load_model(model, stride, quant_bytes=4, multiplier=1.0, models_root=None):
 
     if not models_root is None:
          model_path = os.path.join(models_root, model_path)
+         model_cfg['tf_dir'] = model_path
 
     if not os.path.exists(model_path):
         print('Cannot find tf model path %s, converting from tfjs...' % model_path)

--- a/posenet/posenet_factory.py
+++ b/posenet/posenet_factory.py
@@ -6,7 +6,7 @@ from posenet.mobilenet import MobileNet
 from posenet.posenet import PoseNet
 
 
-def load_model(model, stride, quant_bytes=4, multiplier=1.0):
+def load_model(model, stride, quant_bytes=4, multiplier=1.0, models_root=None):
 
     if model == config.RESNET50_MODEL:
         model_cfg = config.bodypix_resnet50_config(stride, quant_bytes)
@@ -17,8 +17,8 @@ def load_model(model, stride, quant_bytes=4, multiplier=1.0):
 
     model_path = model_cfg['tf_dir']
 
-    if not os.path.exists(model_path):
-         model_path = os.path.join(os.path.dirname(__file__) , model_path)
+    if not models_root is None:
+         model_path = os.path.join(models_root, model_path)
 
     if not os.path.exists(model_path):
         print('Cannot find tf model path %s, converting from tfjs...' % model_path)

--- a/posenet/posenet_factory.py
+++ b/posenet/posenet_factory.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
 import os
 import posenet.converter.config as config
-import posenet.converter.tfjs2tf as tfjs2tf
 from posenet.resnet import ResNet
 from posenet.mobilenet import MobileNet
 from posenet.posenet import PoseNet
@@ -17,8 +16,13 @@ def load_model(model, stride, quant_bytes=4, multiplier=1.0):
         print('Loading MobileNet model')
 
     model_path = model_cfg['tf_dir']
+
+    if not os.path.exists(model_path):
+         model_path = os.path.join(os.path.dirname(__file__) , model_path)
+
     if not os.path.exists(model_path):
         print('Cannot find tf model path %s, converting from tfjs...' % model_path)
+        import posenet.converter.tfjs2tf as tfjs2tf
         tfjs2tf.convert(model_cfg)
         assert os.path.exists(model_path)
 


### PR DESCRIPTION
With this PR, this repo can be more easily converted in a package. A package that might include a downloaded version of the model and that does not need the tfjs2tf dependency runtime (hence why the late/conditional import).